### PR TITLE
Fix text domain references and update plugin metadata

### DIFF
--- a/lib/class-vimeo.php
+++ b/lib/class-vimeo.php
@@ -37,12 +37,12 @@ namespace YTubeFancy {
 		public function vimeofancybox_options() {
 			?>
 			<div class="wrap">
-				<h2><?php esc_html_e( 'Generate Vimeo Shortcode', 'ytubebox' ); ?></h2>
+				<h2><?php esc_html_e( 'Generate Vimeo Shortcode', 'youtubefancybox' ); ?></h2>
 				<hr />
 				<table class="form-table">
 					<tr>
 						<th align="left">
-							<?php esc_html_e( 'Enter Vimeo URL', 'ytubebox' ); ?>
+							<?php esc_html_e( 'Enter Vimeo URL', 'youtubefancybox' ); ?>
 						</th>
 						<td align="left">
 							<input type="text" id="vimeourl" size="80" />
@@ -50,7 +50,7 @@ namespace YTubeFancy {
 					</tr>
 					<tr>
 						<th align="left">
-							<?php esc_html_e( 'Height for Image Thumbnail', 'ytubebox' ); ?>
+							<?php esc_html_e( 'Height for Image Thumbnail', 'youtubefancybox' ); ?>
 						</th>
 						<td align="left">
 							<input type="text" name="t_height" id="t_height" />
@@ -58,7 +58,7 @@ namespace YTubeFancy {
 					</tr>
 					<tr>
 						<th align="left">
-							<?php esc_html_e( 'Width for Image Thumbnail', 'ytubebox' ); ?>
+							<?php esc_html_e( 'Width for Image Thumbnail', 'youtubefancybox' ); ?>
 						</th>
 						<td align="left">
 							<input type="text" name="t_width" id="t_width" />
@@ -69,7 +69,7 @@ namespace YTubeFancy {
 
 						</th>
 						<td align="left">
-							<input type="button" name="getshortcode" value="<?php esc_attr_e( 'Generate', 'ytubebox' ); ?>" id="genratevimeo" class="button button-primary"/>
+							<input type="button" name="getshortcode" value="<?php esc_attr_e( 'Generate', 'youtubefancybox' ); ?>" id="genratevimeo" class="button button-primary"/>
 						</td>
 					</tr>
 					<tr>
@@ -135,7 +135,7 @@ namespace YTubeFancy {
 			}
 
 			if ( empty( $attr['videoid'] ) ) {
-				return '<br /><span style="clear:both;color:red">' . esc_html__( 'Please Enter Vimeo ID or Vimeo URL as [vimeo videoid="XXXXX"]', 'ytubebox' ) . '</span>';
+				return '<br /><span style="clear:both;color:red">' . esc_html__( 'Please Enter Vimeo ID or Vimeo URL as [vimeo videoid="XXXXX"]', 'youtubefancybox' ) . '</span>';
 			}
 
 			if ( is_ssl() ) {
@@ -159,7 +159,7 @@ namespace YTubeFancy {
 					if ( ! empty( $response ) ) {
 						return '<br /><span style="clear:both;color:red">' . $response->get_error_message() . '</span>';
 					}
-					return '<br /><span style="clear:both;color:red">' . esc_html__( 'Error in fetching Vimeo Video Thumbnail', 'ytubebox' ) . '</span>';
+					return '<br /><span style="clear:both;color:red">' . esc_html__( 'Error in fetching Vimeo Video Thumbnail', 'youtubefancybox' ) . '</span>';
 				}
 
 				$response_body = wp_remote_retrieve_body( $response );

--- a/lib/class-vimeo.php
+++ b/lib/class-vimeo.php
@@ -1,4 +1,7 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 /**
  * Description of Vimeo
  *

--- a/lib/class-youtube.php
+++ b/lib/class-youtube.php
@@ -1,4 +1,7 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 /**
  * Description of Youtube
  *

--- a/lib/class-youtube.php
+++ b/lib/class-youtube.php
@@ -77,7 +77,7 @@ namespace YTubeFancy {
 
 			if ( empty( $attr['videoid'] ) ) {
 
-				return '<br /><span style="clear:both;color:red">' . esc_html__( 'Please Enter Youtube ID or Youtube URL as [youtube videoid="XXXXX"]', 'ytubebox' ) . '</span>';
+				return '<br /><span style="clear:both;color:red">' . esc_html__( 'Please Enter Youtube ID or Youtube URL as [youtube videoid="XXXXX"]', 'youtubefancybox' ) . '</span>';
 
 			}
 
@@ -128,12 +128,12 @@ namespace YTubeFancy {
 			?>
 			<div class="wrap">
 
-				<h2><?php esc_html_e( 'Generate Youtube Shortcode', 'ytubebox' ); ?></h2>
+				<h2><?php esc_html_e( 'Generate Youtube Shortcode', 'youtubefancybox' ); ?></h2>
 				<hr />
 				<table class="form-table">
 					<tr>
 						<th align="left">
-							<?php esc_html_e( 'Enter Youtube URL', 'ytubebox' ); ?>
+							<?php esc_html_e( 'Enter Youtube URL', 'youtubefancybox' ); ?>
 						</th>
 						<td align="left">
 							<input type="text" name="youtubeurl" id="youtubeurl" size="80" />
@@ -141,7 +141,7 @@ namespace YTubeFancy {
 					</tr>
 					<tr>
 						<th align="left">
-							<?php esc_html_e( 'Height for Image Thumbnail', 'ytubebox' ); ?>
+							<?php esc_html_e( 'Height for Image Thumbnail', 'youtubefancybox' ); ?>
 						</th>
 						<td align="left">
 							<input type="text" name="t_height" id="t_height" />
@@ -149,7 +149,7 @@ namespace YTubeFancy {
 					</tr>
 					<tr>
 						<th align="left">
-							<?php esc_html_e( 'Width for Image Thumbnail', 'ytubebox' ); ?>
+							<?php esc_html_e( 'Width for Image Thumbnail', 'youtubefancybox' ); ?>
 						</th>
 						<td align="left">
 							<input type="text" name="t_width" id="t_width" />
@@ -160,7 +160,7 @@ namespace YTubeFancy {
 
 						</th>
 						<td align="left">
-							<input type="button" name="getshortcode" value="<?php esc_attr_e( 'Generate', 'ytubebox' ); ?>" id="genrate" class="button button-primary"/>
+							<input type="button" name="getshortcode" value="<?php esc_attr_e( 'Generate', 'youtubefancybox' ); ?>" id="genrate" class="button button-primary"/>
 						</td>
 					</tr>
 					<tr>

--- a/readme.txt
+++ b/readme.txt
@@ -1,14 +1,14 @@
 === Video Lightbox for YouTube/Vimeo ===
 Contributors: milindmore22
 Tags: youtube, vimeo, lightbox, popup-video, shortcode
-Requires at least: 5.6
-Requires PHP: 8.0
-Tested up to: 6.6.2
+Requires at least: 6.7
+Requires PHP: 8.1
+Tested up to: 7.0
 Stable tag: 2.7.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
-Embed YouTube/Vimeo videos in a lightbox popup. Easily create thumbnails and customize playback settings. Supports both platforms and is compatible with WordPress.
+Display YouTube/Vimeo thumbnails that open in a lightbox popup. Easy shortcode generator with custom height, width & autoplay.
 
 == Description ==
 

--- a/youtubefancybox.php
+++ b/youtubefancybox.php
@@ -6,7 +6,7 @@
  * Author: Milind More
  * Author URI: https://milindmore.wordpress.com/
  * Version: 2.7.1
- * Text Domain: ytubebox
+ * Text Domain: youtubefancybox
  * Domain Path: /languages/
  * Requires PHP: 8.1
  *
@@ -67,7 +67,7 @@ namespace YTubeFancy {
 		 * @todo created pdo or mo file for translation
 		 */
 		public function load_plugin_textdomain() {
-			load_plugin_textdomain( 'ytubebox', false, basename( dirname( __FILE__ ) ) . '/languages/' );
+			load_plugin_textdomain( 'youtubefancybox', false, basename( dirname( __FILE__ ) ) . '/languages/' );
 		}
 
 		/**
@@ -87,8 +87,8 @@ namespace YTubeFancy {
 			wp_register_script( 'fancybox_admin', plugins_url( 'js/fancybox_admin.js', __FILE__ ), array( 'jquery' ), $this->version, true );
 
 			$translation_array = array(
-				'youtube_alert' => esc_html__( 'Youtube URL you entered might be wrong, Please enter correct URL!', 'ytubebox' ),
-				'viemo_alert'   => esc_html__( 'Viemo URL you entered might be wrong, Please enter correct URL!', 'ytubebox' ),
+				'youtube_alert' => esc_html__( 'Youtube URL you entered might be wrong, Please enter correct URL!', 'youtubefancybox' ),
+				'viemo_alert'   => esc_html__( 'Viemo URL you entered might be wrong, Please enter correct URL!', 'youtubefancybox' ),
 			);
 
 			wp_localize_script( 'fancybox_admin', 'fancybox_admin_obj', $translation_array );
@@ -143,26 +143,26 @@ namespace YTubeFancy {
 				fieldset { border: 1px solid; }
 			</style>
 			<div class="wrap">
-				<h1><?php esc_html_e( 'Video Lightbox', 'ytubebox' ); ?></h1>
+				<h1><?php esc_html_e( 'Video Lightbox', 'youtubefancybox' ); ?></h1>
 
 				<h2>Set Default Options</h2>
 				<hr />
 				<form action="" method="post">
 					<table class="form-table">
 						<tr>
-							<th align="left"><?php esc_html_e( 'Height', 'ytubebox' ); ?></th>
+							<th align="left"><?php esc_html_e( 'Height', 'youtubefancybox' ); ?></th>
 							<td align="left">
 								<input type="text" name="youtube_height" value="<?php echo esc_attr( get_option( 'youtube_height' ) ); ?>" />
 							</td>
 						</tr>
 						<tr>
-							<th align="left"><?php esc_html_e( 'Width', 'ytubebox' ); ?></th>
+							<th align="left"><?php esc_html_e( 'Width', 'youtubefancybox' ); ?></th>
 							<td align="left">
 								<input type="text" name="youtube_width" value="<?php echo esc_attr( get_option( 'youtube_width' ) ); ?>" />
 							</td>
 						</tr>
 						<tr>
-							<th align="left"><?php esc_html_e( 'Autoplay', 'ytubebox' ); ?></th>
+							<th align="left"><?php esc_html_e( 'Autoplay', 'youtubefancybox' ); ?></th>
 							<td align="left">
 								<input type="radio" name="autoplay" value="yes"
 									<?php
@@ -171,7 +171,7 @@ namespace YTubeFancy {
 									}
 									?>
 								/>
-								<?php esc_html_e( 'Yes', 'ytubebox' ); ?>
+								<?php esc_html_e( 'Yes', 'youtubefancybox' ); ?>
 								<input type="radio" name="autoplay" value="no"
 									<?php
 									if ( 'no' === get_option( 'autoplay' ) ) {
@@ -179,13 +179,13 @@ namespace YTubeFancy {
 									}
 									?>
 								/>
-								<?php esc_html_e( 'No', 'ytubebox' ); ?>
+								<?php esc_html_e( 'No', 'youtubefancybox' ); ?>
 							</td>
 						</tr>
 						<tr>
 							<th align="left"></th>
 							<td align="left">
-								<input type="submit" value="<?php esc_attr_e( 'Save', 'ytubebox' ); ?>" name="submit" class="button button-primary" />
+								<input type="submit" value="<?php esc_attr_e( 'Save', 'youtubefancybox' ); ?>" name="submit" class="button button-primary" />
 							</td>
 						</tr>
 					</table>

--- a/youtubefancybox.php
+++ b/youtubefancybox.php
@@ -1,4 +1,7 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 /**
  * Plugin Name: Video Lightbox for YouTube/Vimeo
  * Plugin URI: https://wordpress.org/plugins/youtubefancybox/
@@ -6,6 +9,10 @@
  * Author: Milind More
  * Author URI: https://milindmore.wordpress.com/
  * Version: 2.7.1
+ * License: GPLv2 or later
+ * License URI: https://www.gnu.org/licenses/gpl-2.0.html
+ * Requires at least: 6.7
+ * Tested up to: 7.0
  * Text Domain: youtubefancybox
  * Domain Path: /languages/
  * Requires PHP: 8.1
@@ -51,7 +58,6 @@ namespace YTubeFancy {
 			add_action( 'wp_enqueue_scripts', array( $this, 'youtubefancybox_js_file' ) );
 			add_filter( 'widget_text', 'shortcode_unautop' );
 			add_filter( 'widget_text', 'do_shortcode' );
-			add_action( 'plugins_loaded', array( $this, 'load_plugin_textdomain' ) );
 		}
 
 		/**
@@ -59,15 +65,6 @@ namespace YTubeFancy {
 		 */
 		public function youtubefancybox_plugin_main_menu() {
 			add_menu_page( 'Video Lightbox for YouTube/Vimeo', 'Video Lightbox', 'manage_options', 'ytubefancybox', array( $this, 'ytubefancybox_default_settings' ), 'dashicons-format-video', 6 );
-		}
-
-		/**
-		 * Function will make plugin translation ready.
-		 *
-		 * @todo created pdo or mo file for translation
-		 */
-		public function load_plugin_textdomain() {
-			load_plugin_textdomain( 'youtubefancybox', false, basename( dirname( __FILE__ ) ) . '/languages/' );
 		}
 
 		/**
@@ -205,13 +202,13 @@ namespace {
 	/**
 	 * Include lib files.
 	 */
-	foreach ( glob( plugin_dir_path( __FILE__ ) . '/lib/*.php' ) as $lib_filename ) {
-		require_once $lib_filename;
+	foreach ( glob( plugin_dir_path( __FILE__ ) . '/lib/*.php' ) as $ytubefancy_lib_filename ) {
+		require_once $ytubefancy_lib_filename;
 	}
 
-	global $fancybox, $youtube, $viemo;
-	$fancybox = new \YTubeFancy\Youtubefanybox();
-	$youtube  = new \YTubeFancy\Youtube();
-	$viemo    = new \YTubeFancy\Vimeo();
+	global $ytubefancy_fancybox, $ytubefancy_youtube, $ytubefancy_viemo;
+	$ytubefancy_fancybox = new \YTubeFancy\Youtubefanybox();
+	$ytubefancy_youtube  = new \YTubeFancy\Youtube();
+	$ytubefancy_viemo    = new \YTubeFancy\Vimeo();
 
 }


### PR DESCRIPTION
This pull request focuses on rebranding the plugin from "ytubebox" to "youtubefancybox" and improving security and code clarity. The most important changes include updating the text domain across all files, enhancing security by preventing direct file access, and updating plugin metadata and documentation to reflect the new branding and compatibility.

**Rebranding and Localization Updates:**
* Changed all occurrences of the text domain from `'ytubebox'` to `'youtubefancybox'` in user-facing strings, translation functions, and shortcode generators in `youtubefancybox.php`, `lib/class-youtube.php`, and `lib/class-vimeo.php` to ensure consistent localization and branding. [[1]](diffhunk://#diff-4e1e4057f1bbd9e39ccf2d2f020d4d9590ea1a983e11f80af51840a66f93f7edL146-R162) [[2]](diffhunk://#diff-4e1e4057f1bbd9e39ccf2d2f020d4d9590ea1a983e11f80af51840a66f93f7edL174-R185) [[3]](diffhunk://#diff-4e1e4057f1bbd9e39ccf2d2f020d4d9590ea1a983e11f80af51840a66f93f7edL90-R88) [[4]](diffhunk://#diff-2cc7a516155866f7bccb34634f0bcb4df6c32ccd0c88497a502e57099ed0892fL40-R64) [[5]](diffhunk://#diff-2cc7a516155866f7bccb34634f0bcb4df6c32ccd0c88497a502e57099ed0892fL72-R75) [[6]](diffhunk://#diff-2cc7a516155866f7bccb34634f0bcb4df6c32ccd0c88497a502e57099ed0892fL138-R141) [[7]](diffhunk://#diff-2cc7a516155866f7bccb34634f0bcb4df6c32ccd0c88497a502e57099ed0892fL162-R165) [[8]](diffhunk://#diff-d75ac434c0b6379dfa2ed2ffd681b2804e42dcdb48ceeb4f83e745470019bd61L80-R83) [[9]](diffhunk://#diff-d75ac434c0b6379dfa2ed2ffd681b2804e42dcdb48ceeb4f83e745470019bd61L131-R155) [[10]](diffhunk://#diff-d75ac434c0b6379dfa2ed2ffd681b2804e42dcdb48ceeb4f83e745470019bd61L163-R166)

**Security Improvements:**
* Added checks at the top of PHP files (`youtubefancybox.php`, `lib/class-youtube.php`, `lib/class-vimeo.php`) to prevent direct access by exiting if `ABSPATH` is not defined. [[1]](diffhunk://#diff-4e1e4057f1bbd9e39ccf2d2f020d4d9590ea1a983e11f80af51840a66f93f7edR2-R16) [[2]](diffhunk://#diff-d75ac434c0b6379dfa2ed2ffd681b2804e42dcdb48ceeb4f83e745470019bd61R2-R4) [[3]](diffhunk://#diff-2cc7a516155866f7bccb34634f0bcb4df6c32ccd0c88497a502e57099ed0892fR2-R4)

**Plugin Metadata and Documentation:**
* Updated plugin header metadata in `youtubefancybox.php` and `readme.txt` to reflect new requirements (`Requires at least: 6.7`, `Requires PHP: 8.1`, `Tested up to: 7.0`), added license fields, and revised the plugin description for clarity and accuracy. [[1]](diffhunk://#diff-4e1e4057f1bbd9e39ccf2d2f020d4d9590ea1a983e11f80af51840a66f93f7edR2-R16) [[2]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L4-R11)

**Codebase Maintenance:**
* Removed the unused `load_plugin_textdomain` function and its associated action, as the text domain has changed and translation loading is now handled differently. [[1]](diffhunk://#diff-4e1e4057f1bbd9e39ccf2d2f020d4d9590ea1a983e11f80af51840a66f93f7edL54) [[2]](diffhunk://#diff-4e1e4057f1bbd9e39ccf2d2f020d4d9590ea1a983e11f80af51840a66f93f7edL64-L72)
* Renamed global variables for plugin instances from `$fancybox`, `$youtube`, `$viemo` to `$ytubefancy_fancybox`, `$ytubefancy_youtube`, `$ytubefancy_viemo` for improved clarity and to avoid naming conflicts.

These changes modernize the plugin, improve security, and ensure consistency in branding and localization throughout the codebase.